### PR TITLE
Look for osr and gdal in the osgeo module as well

### DIFF
--- a/touchterrain/common/TouchTerrainEarthEngine.py
+++ b/touchterrain/common/TouchTerrainEarthEngine.py
@@ -39,7 +39,13 @@ from touchterrain.common.Coordinate_system_conv import * # arc to meters convers
 
 import numpy
 from PIL import Image
-import gdal # for reading/writing geotiffs
+
+# for reading/writing geotiffs
+# Later versions of gdal may be bundled into osgeo so check there as well.
+try:
+    import gdal
+except ImportError as err:
+    from osgeo import gdal
 
 import time
 import random

--- a/touchterrain/common/TouchTerrainGPX.py
+++ b/touchterrain/common/TouchTerrainGPX.py
@@ -183,7 +183,12 @@ def addGPXToModel(pr,npim,dem,importedGPX,gpxPathHeight,gpxPixelsBetweenPoints,g
 
     """ 
     import xml.etree.ElementTree as ET 
-    import osr 
+
+    # Later versions of osr may be bundled into osgeo so check there as well.
+    try:
+        import osr
+    except ImportError as err:
+        from osgeo import osr
     import time 
     import math
 


### PR DESCRIPTION
Some library versions put gdal and osr inside osgeo and thus can't be found with a simple import.  Check for them within the module as well.