### PR TITLE
Added GPX plotting for local imported DEM and multi-track GPX file support and progress indication

### DIFF
--- a/touchterrain/common/TouchTerrainEarthEngine.py
+++ b/touchterrain/common/TouchTerrainEarthEngine.py
@@ -981,6 +981,14 @@ def get_zipped_tiles(DEM_name=None, trlat=None, trlon=None, bllat=None, bllon=No
             undef_cells = numpy.isclose(npim, gdal_undef_val) # bool
             npim = numpy.where(undef_cells, numpy.nan, npim)
 
+        # Add GPX points to the model (thanks KohlhardtC!)
+        if importedGPX != None and importedGPX != []:
+            from touchterrain.common.TouchTerrainGPX import addGPXToModel 
+            print("TEST\nTEST\nTEST") 
+            addGPXToModel(pr, npim, dem, importedGPX, 
+                          gpxPathHeight, gpxPixelsBetweenPoints, gpxPathThickness, 
+                          trlat, trlon, bllat, bllon) 
+
         # clip values?
         if ignore_leq != None:
             npim = numpy.where(npim <= ignore_leq, numpy.nan, npim)


### PR DESCRIPTION
Chris,

I added a call to GPX plotting that appeared to be missing when using a local imported DEM with `importedDEM` option.
Multi-track GPX support was implemented by plotting all found `trk` elements versus only the first one. This is useful for GPX exports from line type shapefiles with multiple lines. 


_P.S. I also added code to "lower" specific regions by importing a mask GeoTIFF. This would be similar to the `lower_leq` option but independent of existing elevation values. Ex: Lakes and rivers in the mountains and along the coast can be simultaneously lowered (seen below). I didn't put this feature in this commit to reduce complexity and can create a new pull request once this gpx one makes it upstream._ 

![image](https://user-images.githubusercontent.com/546458/127588437-cc400650-a3eb-42a4-b4fb-97e0a0da29e9.png)
