### PR TITLE
Fix offset_masks_lower feature to work with custom printres and multi-tile prints. 

### DIFF
--- a/touchterrain/common/TouchTerrainEarthEngine.py
+++ b/touchterrain/common/TouchTerrainEarthEngine.py
@@ -1100,6 +1100,9 @@ def get_zipped_tiles(DEM_name=None, trlat=None, trlon=None, bllat=None, bllon=No
             npim = npim[0:npim.shape[0]-remy, 0:npim.shape[1]-remx]
             pr(" cropped", old_shape[::-1], "to", npim.shape[::-1]   )
 
+            for offset_layer in offset_npim:
+                offset_layer = offset_layer[0:offset_layer.shape[0]-remy, 0:offset_layer.shape[1]-remx]
+
             # adjust tile width and height to reflect the smaller, cropped raster
             ratio = old_shape[0] / float(npim.shape[0]), old_shape[1] / float(npim.shape[1])
             pr(" cropping changed physical size from", print3D_width_per_tile, "mm x", print3D_height_per_tile, "mm")

--- a/touchterrain/common/TouchTerrainEarthEngine.py
+++ b/touchterrain/common/TouchTerrainEarthEngine.py
@@ -1046,8 +1046,9 @@ def get_zipped_tiles(DEM_name=None, trlat=None, trlon=None, bllat=None, bllon=No
             npim =  resampleDEM(npim, scale_factor)
 
             # re-sample offset mask
-            for offset_layer in offset_npim:
-                offset_layer =  resampleDEM(offset_layer, scale_factor)
+            for index, offset_layer in enumerate(offset_npim):
+                pr("re-sampling offset layer",index, ":\n ", offset_layer.shape[::-1], source_print3D_resolution, "mm ", cell_size_m, "m ", numpy.nanmin(offset_layer), "-", numpy.nanmax(offset_layer), "m to")
+                offset_npim[index] = resampleDEM(offset_layer, scale_factor)
 
             #
             # based on the full raster's shape and given the model width, recalc the model height
@@ -1100,8 +1101,8 @@ def get_zipped_tiles(DEM_name=None, trlat=None, trlon=None, bllat=None, bllon=No
             npim = npim[0:npim.shape[0]-remy, 0:npim.shape[1]-remx]
             pr(" cropped", old_shape[::-1], "to", npim.shape[::-1]   )
 
-            for offset_layer in offset_npim:
-                offset_layer = offset_layer[0:offset_layer.shape[0]-remy, 0:offset_layer.shape[1]-remx]
+            for index, offset_layer in enumerate(offset_npim):
+                offset_npim[index] = offset_layer[0:offset_layer.shape[0]-remy, 0:offset_layer.shape[1]-remx]
 
             # adjust tile width and height to reflect the smaller, cropped raster
             ratio = old_shape[0] / float(npim.shape[0]), old_shape[1] / float(npim.shape[1])


### PR DESCRIPTION
Added code to resample and crop offset mask layer rasters correctly. 

`offset_masks_lower `now works with `printres` and multi-tile prints. This was noticed in #49 