### PR TITLE
Fix unbound error for offset_npim

### DIFF
--- a/touchterrain/common/TouchTerrainEarthEngine.py
+++ b/touchterrain/common/TouchTerrainEarthEngine.py
@@ -570,7 +570,8 @@ def get_zipped_tiles(DEM_name=None, trlat=None, trlon=None, bllat=None, bllon=No
 
     # end of polygon stuff
 
-
+    # This is needed to avoid python unbound error since offset_npim is currently only available for local DEMs in standalone python script
+    offset_npim = []
 
     #
     # A) use Earth Engine to download DEM geotiff
@@ -949,7 +950,7 @@ def get_zipped_tiles(DEM_name=None, trlat=None, trlon=None, bllat=None, bllon=No
         npim = band.ReadAsArray().astype(numpy.float64)
 
         # Read in offset mask file
-        offset_npim = []
+        # offset_npim = [] # Define offset_npim in parent scope before importedDEM "if statement" to avoid python unbound error
         if offset_masks_lower is not None:
             offset_dem = gdal.Open(offset_masks_lower[0][0])
             offset_band = offset_dem.GetRasterBand(1)


### PR DESCRIPTION
This fixes #51 

offset_npim was not defined yet due to offset mask functionality currently only available for local DEM in standalone py file
Fixed by defining offset_npim earlier so that it is defined when used from jupyter notebook. 

![rhode island test](https://user-images.githubusercontent.com/546458/129979523-f1199bda-3bf2-4c50-b28b-a630af36f139.png)
