### PR TITLE
Updates for new python container

### DIFF
--- a/touchterrain/server/gunicorn_settings.py
+++ b/touchterrain/server/gunicorn_settings.py
@@ -2,3 +2,7 @@
 # Note that if you've got another router in front of this, like haproxy or heroku or openshift, 
 # you might need to change the timeout there too
 timeout = 5 * 60
+
+# required for newer python container
+accesslog = '-'
+bind = ['0.0.0.0:8080']


### PR DESCRIPTION
If the website deployment is updated to use a newer python container without these settings it will break