### PR TITLE
Correct latitude and longitude reference to easting and northing

### DIFF
--- a/touchterrain/common/Coordinate_system_conv.py
+++ b/touchterrain/common/Coordinate_system_conv.py
@@ -29,7 +29,7 @@ def arcDegr_in_meter(latitude_in_degr):
       
 
 def LatLon_to_UTM(arg1, arg2=None):
-    """ given latitude (easting) and longitude (northing) as floats,
+    """ given longitude (easting) and latitude (northing) as floats,
         return the UTM zone number (1 to 60) and "N" for North or "S" for South as a tuple
         or -1 on error
         


### PR DESCRIPTION
I believe the language in the documentation for the `LatLon_to_UTM` incorrectly refers to the first (easting) argument as the latitude and the second (northing) argument as the longitude.  These should be reversed.