### PR TITLE
Allow flask_local mode to run without API keys

### DIFF
--- a/touchterrain/common/TouchTerrainEarthEngine.py
+++ b/touchterrain/common/TouchTerrainEarthEngine.py
@@ -82,6 +82,7 @@ logger.setLevel(logging.INFO)
 # crap from happening. It assumes that any "main" file imports TouchTerrainEarthEngine anyway.
 # But, as this could also be run in a standalone scenario where EE should not be involved,
 # the failed to EE init messages are just warnings
+EE_INITIALIZED = False
 try:
     import ee
     # uses .config/earthengine/credentials, since Nov. 2024 this must be a service account json file not a p12 file!
@@ -89,6 +90,7 @@ try:
     # Authenticate using the service account
     credentials = ee.ServiceAccountCredentials(EE_ACCOUNT, EE_CREDS)
     ee.Initialize(credentials, project=EE_PROJECT)
+    EE_INITIALIZED = True
 except Exception as e:
     logging.warning(f"EE init() error (with {EE_CREDS}) {e} (This is OK if you don't use earthengine anyway!)")
 else:

--- a/touchterrain/server/TouchTerrain_app.py
+++ b/touchterrain/server/TouchTerrain_app.py
@@ -44,6 +44,7 @@ app = Flask(__name__)
 
 # import modules from common
 from touchterrain.common import TouchTerrainEarthEngine # will also init EE
+from touchterrain.common.TouchTerrainEarthEngine import EE_INITIALIZED
 from touchterrain.common.Coordinate_system_conv import * # arc to meters conversion
 
 import logging
@@ -66,9 +67,10 @@ except:
 # CH Jun 27, 2025 disabled Google Maps
 google_maps_key = ""      
 
-# RecaptchaKeys.txt in server folder must contain keys for recaptcha site key, 
-# recaptcha secret key and flask secret key as single strings in separate lines 
+# RecaptchaKeys.txt in server folder must contain keys for recaptcha site key,
+# recaptcha secret key and flask secret key as single strings in separate lines
 
+CAPTCHA_ENABLED = True
 try:
     with open(RECAPTCHA_V3_KEYS_FILE) as f:
         lines = f.readlines()
@@ -77,8 +79,19 @@ try:
         app.config['RECAPTCHA_SECRET_KEY'] = keys[1]
         app.secret_key = keys[2]
 except:
-     # file does not exist - will show the ugly Google map version
-     sys.exit("Problem with RecaptchaKeys.txt in server folder, it must contain keys for the (v3) recaptcha site key, recaptcha secret key and flask secret key as single strings in separate lines. Exiting.")
+    if SERVER_TYPE == "flask_local":
+        # In local dev mode, allow running without captcha
+        CAPTCHA_ENABLED = False
+        app.config['RECAPTCHA_SITE_KEY'] = None
+        app.config['RECAPTCHA_SECRET_KEY'] = None
+        app.secret_key = 'dev-secret-key-not-for-production'
+        logging.warning("=" * 60)
+        logging.warning("CAPTCHA DISABLED - Running in flask_local mode without reCAPTCHA keys")
+        logging.warning("This is fine for development but NOT for production!")
+        logging.warning("=" * 60)
+    else:
+        # Production mode requires captcha keys
+        sys.exit("Problem with RecaptchaKeys.txt in server folder, it must contain keys for the (v3) recaptcha site key, recaptcha secret key and flask secret key as single strings in separate lines. Exiting.")
 else:
     print("Recaptcha_v3_keys.txt sucessfully parsed.")
 
@@ -135,11 +148,17 @@ def make_GA_script(page_title):
     """
     return html
 
-# entry page that shows a world map does the Recaptch_v3 and, if passed, 
+# entry page that shows a world map does the Recaptch_v3 and, if passed,
 # loads the main page when clicked
 @app.route('/', methods=['GET', 'POST'])
 def intro_page():
     if request.method == 'POST':
+        # If captcha is disabled (flask_local without keys), auto-verify
+        if not CAPTCHA_ENABLED:
+            session['recaptcha_verified'] = True
+            print("CAPTCHA DISABLED - auto-verifying user (flask_local mode)", file=sys.stderr)
+            return redirect(url_for('main_page'))
+
         token = request.form.get('g-recaptcha-response')
         if token and verify_recaptcha(token):
             session['recaptcha_verified'] = True  # Store in Flask session
@@ -151,9 +170,10 @@ def intro_page():
             return render_template(
                 'intro.html',
                 site_key=app.config['RECAPTCHA_SITE_KEY'],
+                captcha_enabled=CAPTCHA_ENABLED,
                 error=f"reCAPTCHA.v3 failed with score {app.config['score']} < {app.config['score_threshold']}. If you're not a bot, you may be penalized for using privacy tools, a VPN, or incognito mode. Disable them and try again. (Sorry!)"
             )
-    return render_template('intro.html', site_key=app.config['RECAPTCHA_SITE_KEY'])
+    return render_template('intro.html', site_key=app.config['RECAPTCHA_SITE_KEY'], captcha_enabled=CAPTCHA_ENABLED)
 
 #
 # The page for selecting the ROI and putting in printer parameters
@@ -213,25 +233,36 @@ def main_page():
         args[key] = request.args[key]
         #print(key, request.args[key])
 
-    # get hillshade for elevation
-    if args["DEM_name"] in ("NRCan/CDEM", "AU/GA/AUSTRALIA_5M_DEM"):  # Image collection?
-        dataset = ee.ImageCollection(args["DEM_name"])
-        elev = dataset.select('elevation')
-        proj = elev.first().select(0).projection() # must use common projection(?)
-        elev = elev.mosaic().setDefaultProjection(proj) # must mosaic collection into single image
+    # get hillshade for elevation from Earth Engine (if available)
+    if EE_INITIALIZED:
+        if args["DEM_name"] in ("NRCan/CDEM", "AU/GA/AUSTRALIA_5M_DEM"):  # Image collection?
+            dataset = ee.ImageCollection(args["DEM_name"])
+            elev = dataset.select('elevation')
+            proj = elev.first().select(0).projection() # must use common projection(?)
+            elev = elev.mosaic().setDefaultProjection(proj) # must mosaic collection into single image
+        else:
+            elev = ee.Image(args["DEM_name"])
+
+        hsazi = float(args["hsazi"]) # compass heading of sun
+        hselev = float(args["hselev"]) # angle of sun above the horizon
+        hs = ee.Terrain.hillshade(elev, hsazi, hselev)
+
+        gamma = float(args["gamma"])
+        mapid = hs.getMapId( {'gamma':gamma}) # request map from EE, transparency will be set in JS
+
+        # these have to be added to the args so they end up in the template
+        args['mapid'] = mapid['mapid']
+        #args['token'] = mapid['token'] # no token needed anymore
+        args['ee_available'] = True
     else:
-        elev = ee.Image(args["DEM_name"])
-
-    hsazi = float(args["hsazi"]) # compass heading of sun
-    hselev = float(args["hselev"]) # angle of sun above the horizon
-    hs = ee.Terrain.hillshade(elev, hsazi, hselev)
-
-    gamma = float(args["gamma"])
-    mapid = hs.getMapId( {'gamma':gamma}) # request map from EE, transparency will be set in JS
-
-    # these have to be added to the args so they end up in the template
-    args['mapid'] = mapid['mapid']
-    #args['token'] = mapid['token'] # no token needed anymore
+        # EE not initialized - in flask_local mode this is OK, just skip hillshade
+        if SERVER_TYPE == "flask_local":
+            logging.warning("EE not available - hillshade overlay will be disabled")
+            args['mapid'] = ''
+            args['ee_available'] = False
+        else:
+            # Production mode requires EE
+            raise RuntimeError("Earth Engine not initialized. Check credentials.")
    
     # in manual, replace " with \" i.e. ""ignore_leq":123" -> "\"ignore_leq\":123"
     # so that it's a valid JS string after it's been inlined
@@ -247,7 +278,7 @@ def main_page():
 
     # if user has not been verified yet, show the intro page to get the reCAPTCHA
     print("User has not been verified, showing intro page.", file=sys.stderr)
-    return render_template('intro.html', site_key=app.config['RECAPTCHA_SITE_KEY'])
+    return render_template('intro.html', site_key=app.config['RECAPTCHA_SITE_KEY'], captcha_enabled=CAPTCHA_ENABLED)
 
 # Page that unzips the tiles and shows a preview of the STL files using a template
 @app.route("/preview/<string:zip_file>")

--- a/touchterrain/server/templates/index.html
+++ b/touchterrain/server/templates/index.html
@@ -56,6 +56,11 @@
 	</head>
 
 	<body>
+		{% if not ee_available %}
+		<div style="background-color: #fff3cd; border: 1px solid #ffc107; color: #856404; padding: 12px; margin: 10px; border-radius: 4px; font-family: sans-serif;">
+			<strong>Development Mode:</strong> Earth Engine is not configured. Hillshade overlay is disabled. You can still use local GeoTIFF files for terrain generation.
+		</div>
+		{% endif %}
 		<div class="container-fluid" id="outermost_div">
 			<div class="page-header text-truncate" style="min-width: 635px;">
 			  <h4 class="text-truncate">

--- a/touchterrain/server/templates/intro.html
+++ b/touchterrain/server/templates/intro.html
@@ -9,7 +9,7 @@
         <meta name="keywords" content="HTML, JavaScript, 3D-printing, CNC, STL, terrain data, free">
         <meta name="author" content="Chris Harding">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    
+
         {% if GOOGLE_ANALYTICS_TRACKING_ID %}
         <script async src="https://www.googletagmanager.com/gtag/js?id={{GOOGLE_ANALYTICS_TRACKING_ID}}"></script>
         <script>
@@ -19,9 +19,8 @@
             gtag('config', '{{GOOGLE_ANALYTICS_TRACKING_ID}}');
         </script>
         {% endif %}
-    
 
-        <meta charset="UTF-8">
+        {% if captcha_enabled %}
         <script src="https://www.google.com/recaptcha/api.js?render={{ site_key }}"></script>
         <script>
             function onImageClick(e) {
@@ -34,8 +33,21 @@
                 });
             }
         </script>
+        {% else %}
+        <script>
+            function onImageClick(e) {
+                e.preventDefault();
+                document.getElementById('recaptcha-form').submit();
+            }
+        </script>
+        {% endif %}
     </head>
     <body>
+        {% if not captcha_enabled %}
+        <div style="background-color: #fff3cd; border: 1px solid #ffc107; color: #856404; padding: 12px; margin: 10px; border-radius: 4px; font-family: sans-serif;">
+            <strong>Development Mode:</strong> reCAPTCHA is disabled. This server is running in flask_local mode without captcha keys.
+        </div>
+        {% endif %}
         {% if error %}
         <p style="color: red;">{{ error }}</p>
         {% endif %}

--- a/touchterrain/server/templates/touchterrain.js
+++ b/touchterrain/server/templates/touchterrain.js
@@ -144,7 +144,13 @@ window.onload = function () {
       });
       */
     
-    eemap = create_overlay(MAPID, map); // (global) hillshade overlay from google earth engine
+    // Create hillshade overlay from Earth Engine (if available)
+    if (MAPID && MAPID !== "") {
+        eemap = create_overlay(MAPID, map); // (global) hillshade overlay from google earth engine
+    } else {
+        eemap = null; // EE not available, no hillshade overlay
+        console.log("Earth Engine not available - hillshade overlay disabled");
+    }
     init_print_options(); //update all print option values in the GUI to what was inlined by jinja
     update_options_hidden(); // also store values in hidden ids
     SetDEM_name();  // sets DEM_name pulldown to what was inlined by jinja

--- a/touchterrain/server/templates/touchterrain.js
+++ b/touchterrain/server/templates/touchterrain.js
@@ -870,7 +870,9 @@ function SetDEM_name(){
 // set opacity of hillshade as inverse of transparency given
 function updateTransparency(transparency_pct) {
     let op = 1.0 - transparency_pct / 100.0 // opacity
-    map.overlayMapTypes.getAt(0).setOpacity(op)
+    if (map.overlayMapTypes.getLength() > 0) {
+        map.overlayMapTypes.getAt(0).setOpacity(op)
+    }
     document.getElementById('hillshade_transparency_slider').value=transparency_pct;
     document.getElementById('transp').value=transparency_pct; // id in hidden reload 1
     document.getElementById('transp3').value=transparency_pct; // id in hidden reload 2


### PR DESCRIPTION
## Summary

In preparation for working on accessibility UI improvements, this PR adds support for running the development server without requiring reCAPTCHA or Earth Engine credentials.

- When `SERVER_TYPE = "flask_local"` and reCAPTCHA keys are missing, users are auto-verified through the intro page
- When Earth Engine credentials are missing, the hillshade overlay is skipped but the map still loads
- Warning banners are displayed in both cases to indicate development mode
- Production mode (`gunicorn`) behavior is unchanged - all credentials still required

## Test plan

- [ ] Set `SERVER_TYPE = "flask_local"` in `touchterrain/server/config.py`
- [ ] Remove or rename reCAPTCHA keys file (`/tmp/Recaptcha_v3_keys.txt`)
- [ ] Run server with `python touchterrain/server/Run_TouchTerrain_debug_server_app.py`
- [ ] Verify warning banners appear on intro and main pages
- [ ] Verify clicking through intro page works without captcha
- [ ] Verify map loads (without hillshade overlay)